### PR TITLE
Add RNG: GLibCRand

### DIFF
--- a/orng.c
+++ b/orng.c
@@ -33,6 +33,100 @@
 	ZEND_PARSE_PARAMETERS_END()
 #endif
 
+static zend_object_handlers orng_object_handlers_GLibCRand;
+
+static zend_object *php_orng_GLibCRand_new(zend_class_entry *ce)
+{
+	php_orng_GLibCRand_obj *obj = (php_orng_GLibCRand_obj*)ecalloc(1, sizeof(php_orng_GLibCRand_obj) + zend_object_properties_size(ce));
+	zend_object_std_init(&obj->std, ce);
+	object_properties_init(&obj->std, ce);
+	obj->std.handlers = &orng_object_handlers_GLibCRand;
+	return &obj->std;
+}
+
+static void php_orng_GLibCRand_destroy_object(zend_object *object)
+{
+	php_orng_GLibCRand_obj *obj = php_orng_GLibCRand_from_obj(object);
+	zend_objects_destroy_object(object);
+}
+
+static void php_orng_GLibCRand_object_free_storage(zend_object *object)
+{
+	php_orng_GLibCRand_obj *obj = php_orng_GLibCRand_from_obj(object);
+	zend_object_std_dtor(&obj->std);
+}
+
+PHPAPI zend_long php_orng_GLibCRand_next(php_orng_GLibCRand_obj *object)
+{
+	zend_long ret;
+
+	unsigned int x = object->r[object->next % 344] = object->r[(object->next + 313) % 344] + object->r[(object->next + 341) % 344];
+	object->next = (object->next + 1) % 344;
+	ret = (x >> 1);
+
+	return ret;
+}
+
+/* {{{ \ORNG\GLibCRand::__construct(int $seed) */
+PHP_METHOD(ORNG_GLibCRand, __construct)
+{
+	zend_long seed;
+
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_LONG(seed);
+	ZEND_PARSE_PARAMETERS_END();
+
+	php_orng_GLibCRand_obj *obj = Z_ORNG_GLibCRand_P(getThis());
+
+	unsigned int seed_real = (unsigned int) seed;
+	int i;
+
+	if (seed_real == 0) {
+		seed_real = 1;
+	}
+
+	obj->r[0] = seed_real;
+	for (i = 1; i < 31; i++) {
+		obj->r[i] = (unsigned int)((16807 * (unsigned long) obj->r[i - 1]) % 2147483647);
+	}
+	for (i = 31; i < 34; i++) {
+		obj->r[i] = obj->r[i - 31];
+	}
+	for (i = 34; i < 344; i++) {
+		obj->r[i] = obj->r[i - 31] + obj->r[i - 3];
+	}
+
+	obj->next = 0;
+}
+/* }}} */
+
+/* {{{ \ORNG\GLibCRand::next(): int */
+PHP_METHOD(ORNG_GLibCRand, next)
+{
+	php_orng_GLibCRand_obj *obj = Z_ORNG_GLibCRand_P(getThis());
+	RETURN_LONG(php_orng_GLibCRand_next(obj));
+}
+/* }}} */
+
+/* {{{ \ORNG\GLibCRand::range(int $min, int $max): int */
+PHP_METHOD(ORNG_GLibCRand, range)
+{
+	zend_long min, max, n;
+
+	ZEND_PARSE_PARAMETERS_START(2, 2)
+		Z_PARAM_LONG(min)
+		Z_PARAM_LONG(max)
+	ZEND_PARSE_PARAMETERS_END();
+
+	php_orng_GLibCRand_obj *obj = Z_ORNG_GLibCRand_P(getThis());
+
+	n = php_orng_GLibCRand_next(obj);
+	n = min + (zend_long) ((double) ((double) max - min + 1.0) * (n / (2147483647 + 1.0)));
+
+	RETURN_LONG(n);
+}
+/* }}} */
+
 static zend_object_handlers orng_object_handlers_XorShift128Plus;
 
 static zend_object *php_orng_XorShift128Plus_new(zend_class_entry *ce)
@@ -166,6 +260,17 @@ PHP_MINIT_FUNCTION(orng)
 	zend_class_entry orng_RNGInterface;
 	INIT_CLASS_ENTRY(orng_RNGInterface, "ORNG\\RNGInterface", class_ORNG_RNGInterface_methods);
 	orng_ce_RNGInterface = zend_register_internal_interface(&orng_RNGInterface);
+
+	zend_class_entry orng_GLibCRand;
+	INIT_CLASS_ENTRY(orng_GLibCRand, "ORNG\\GLibCRand", class_ORNG_GLibCRand_methods);
+	orng_ce_GLibCRand = zend_register_internal_class(&orng_GLibCRand);
+	zend_class_implements(orng_ce_GLibCRand, 1, orng_ce_RNGInterface);
+	orng_ce_GLibCRand->create_object = php_orng_GLibCRand_new;
+	memcpy(&orng_object_handlers_GLibCRand, zend_get_std_object_handlers(), sizeof(zend_object_handlers));
+	orng_object_handlers_GLibCRand.offset = XtOffsetOf(php_orng_GLibCRand_obj, std);
+	orng_object_handlers_GLibCRand.clone_obj = NULL;
+	orng_object_handlers_GLibCRand.dtor_obj = php_orng_GLibCRand_destroy_object;
+	orng_object_handlers_GLibCRand.free_obj = php_orng_GLibCRand_object_free_storage;
 
 	zend_class_entry orng_XorShift128Plus;
 	INIT_CLASS_ENTRY(orng_XorShift128Plus, "ORNG\\XorShift128Plus", class_ORNG_XorShift128Plus_methods);

--- a/orng.stub.php
+++ b/orng.stub.php
@@ -11,6 +11,13 @@ interface RNGInterface
     public function range(int $min, int $max): int;
 }
 
+class GLibCRand implements RNGInterface
+{
+    public function __construct(int $seed) {}
+    public function next(): int {}
+    public function range(int $min, int $max): int {}
+}
+
 class XorShift128Plus implements RNGInterface
 {
     public function __construct(int $seed) {}

--- a/orng_arginfo.h
+++ b/orng_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 7e3885031c98b27dfc0f365d51f5da5311f1ccf6 */
+ * Stub hash: 792baaf94c7feb0b273934a1c7a1b82e9e709c39 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_ORNG_RNGInterface___construct, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, seed, IS_LONG, 0)
@@ -13,6 +13,12 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_ORNG_RNGInterface_range, 0
 	ZEND_ARG_TYPE_INFO(0, max, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
+#define arginfo_class_ORNG_GLibCRand___construct arginfo_class_ORNG_RNGInterface___construct
+
+#define arginfo_class_ORNG_GLibCRand_next arginfo_class_ORNG_RNGInterface_next
+
+#define arginfo_class_ORNG_GLibCRand_range arginfo_class_ORNG_RNGInterface_range
+
 #define arginfo_class_ORNG_XorShift128Plus___construct arginfo_class_ORNG_RNGInterface___construct
 
 #define arginfo_class_ORNG_XorShift128Plus_next arginfo_class_ORNG_RNGInterface_next
@@ -20,6 +26,9 @@ ZEND_END_ARG_INFO()
 #define arginfo_class_ORNG_XorShift128Plus_range arginfo_class_ORNG_RNGInterface_range
 
 
+ZEND_METHOD(ORNG_GLibCRand, __construct);
+ZEND_METHOD(ORNG_GLibCRand, next);
+ZEND_METHOD(ORNG_GLibCRand, range);
 ZEND_METHOD(ORNG_XorShift128Plus, __construct);
 ZEND_METHOD(ORNG_XorShift128Plus, next);
 ZEND_METHOD(ORNG_XorShift128Plus, range);
@@ -29,6 +38,14 @@ static const zend_function_entry class_ORNG_RNGInterface_methods[] = {
 	ZEND_ABSTRACT_ME_WITH_FLAGS(ORNG_RNGInterface, __construct, arginfo_class_ORNG_RNGInterface___construct, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
 	ZEND_ABSTRACT_ME_WITH_FLAGS(ORNG_RNGInterface, next, arginfo_class_ORNG_RNGInterface_next, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
 	ZEND_ABSTRACT_ME_WITH_FLAGS(ORNG_RNGInterface, range, arginfo_class_ORNG_RNGInterface_range, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
+	ZEND_FE_END
+};
+
+
+static const zend_function_entry class_ORNG_GLibCRand_methods[] = {
+	ZEND_ME(ORNG_GLibCRand, __construct, arginfo_class_ORNG_GLibCRand___construct, ZEND_ACC_PUBLIC)
+	ZEND_ME(ORNG_GLibCRand, next, arginfo_class_ORNG_GLibCRand_next, ZEND_ACC_PUBLIC)
+	ZEND_ME(ORNG_GLibCRand, range, arginfo_class_ORNG_GLibCRand_range, ZEND_ACC_PUBLIC)
 	ZEND_FE_END
 };
 

--- a/php_orng.h
+++ b/php_orng.h
@@ -1,5 +1,3 @@
-/* orng extension for PHP */
-
 #ifndef PHP_ORNG_H
 # define PHP_ORNG_H
 
@@ -13,6 +11,21 @@ PHP_MSHUTDOWN_FUNCTION(orng);
 PHP_MINFO_FUNCTION(orng);
 
 PHPAPI zend_class_entry *orng_ce_RNGInterface;
+
+PHPAPI zend_class_entry *orng_ce_GLibCRand;
+
+typedef struct _php_orng_GLibCRand_obj {
+	zend_long r[344];
+	int next;
+	zend_object std;
+} php_orng_GLibCRand_obj;
+
+static inline php_orng_GLibCRand_obj *php_orng_GLibCRand_from_obj(zend_object *obj) {
+	return (php_orng_GLibCRand_obj*)((char*)(obj) - XtOffsetOf(php_orng_GLibCRand_obj, std));
+}
+
+# define Z_ORNG_GLibCRand_P(zval) php_orng_GLibCRand_from_obj(Z_OBJ_P(zval))
+
 PHPAPI zend_class_entry *orng_ce_XorShift128Plus;
 
 typedef struct _php_orng_XorShift128Plus_obj {
@@ -24,7 +37,7 @@ static inline php_orng_XorShift128Plus_obj *php_orng_XorShift128Plus_from_obj(ze
 	return (php_orng_XorShift128Plus_obj*)((char*)(obj) - XtOffsetOf(php_orng_XorShift128Plus_obj, std));
 }
 
-#define Z_ORNG_XorShift128Plus_P(zval) php_orng_XorShift128Plus_from_obj(Z_OBJ_P(zval))
+# define Z_ORNG_XorShift128Plus_P(zval) php_orng_XorShift128Plus_from_obj(Z_OBJ_P(zval))
 
 # define PHP_ORNG_VERSION "0.0.0"
 

--- a/tests/002_inheritance.phpt
+++ b/tests/002_inheritance.phpt
@@ -12,6 +12,7 @@ const SEED = 50;
 
 $classes = [
     \ORNG\XorShift128Plus::class,
+    \ORNG\GLibCRand::class,
 ];
 
 foreach ($classes as $class) {

--- a/tests/003_pollution.phpt
+++ b/tests/003_pollution.phpt
@@ -12,6 +12,7 @@ const SEED = 50;
 
 $classes = [
     \ORNG\XorShift128Plus::class,
+    \ORNG\GLibCRand::class,
 ];
 
 foreach ($classes as $class) {

--- a/tests/004_range.phpt
+++ b/tests/004_range.phpt
@@ -14,6 +14,7 @@ const EXCEPT_MAX = 20;
 
 $classes = [
     \ORNG\XorShift128Plus::class,
+    \ORNG\GLibCRand::class,
 ];
 $excepts = range(EXCEPT_MIN, EXCEPT_MAX);
 


### PR DESCRIPTION
`\ORNG\GLibCRand` returns results that are compatible with PHP 7.0 (NTS) or less srand / rand in the GNU LibC environment.
This is useful for old application compatibility.

related: #2 