### PR TITLE
Fix shared library builds for Windows

### DIFF
--- a/config.w32
+++ b/config.w32
@@ -11,4 +11,6 @@ if (PHP_ORNG != 'no') {
 		xorshift128plus.c \
 		mt19937.c \
 		", "orng");
+
+	ADD_FLAG("CFLAGS_ORNG", " /D PHP_ORNG_EXPORTS=1");
 }

--- a/php_orng.h
+++ b/php_orng.h
@@ -19,6 +19,18 @@
 #ifndef PHP_ORNG_H
 # define PHP_ORNG_H
 
+# ifdef PHP_WIN32
+#  ifdef PHP_ORNG_EXPORTS
+#   define PHP_ORNG_API __declspec(dllexport)
+#  else
+#   define PHP_ORNG_API
+#  endif
+# elif defined(__GNUC__) && __GNUC__ >= 4
+#  define PHP_ORNG_API __attribute__ ((visibility("default")))
+# else
+#  define PHP_ORNG_API
+# endif
+
 # define ORNG_RNG_FQN(__cn) "ORNG\\"#__cn
 
 extern zend_module_entry orng_module_entry;

--- a/php_orng.h
+++ b/php_orng.h
@@ -23,7 +23,7 @@
 #  ifdef PHP_ORNG_EXPORTS
 #   define PHP_ORNG_API __declspec(dllexport)
 #  else
-#   define PHP_ORNG_API
+#   define PHP_ORNG_API __declspec(dllimport)
 #  endif
 # elif defined(__GNUC__) && __GNUC__ >= 4
 #  define PHP_ORNG_API __attribute__ ((visibility("default")))

--- a/rng/glibcrand.c
+++ b/rng/glibcrand.c
@@ -40,7 +40,7 @@
 # include "glibcrand_arginfo_7.h"
 #endif
 
-PHPAPI zend_class_entry *ce_ORNG_GLibCRand;
+PHP_ORNG_API zend_class_entry *ce_ORNG_GLibCRand;
 
 static zend_object_handlers oh_GLibCRand;
 

--- a/rng/glibcrand.h
+++ b/rng/glibcrand.h
@@ -23,7 +23,7 @@
 
 # include "../orng_util.h"
 
-extern PHPAPI zend_class_entry *ce_ORNG_GLibCRand;
+extern PHP_ORNG_API zend_class_entry *ce_ORNG_GLibCRand;
 
 /* System Rand functions */
 # ifndef ORNG_GLIBCRAND_MAX

--- a/rng/mt19937.c
+++ b/rng/mt19937.c
@@ -38,9 +38,9 @@
 // Note: "mt19937php_arghinfo.h" is not required.
 // Note: "mt19937mb_arginfo.h" is not required.
 
-PHPAPI zend_class_entry *ce_ORNG_MT19937;
-PHPAPI zend_class_entry *ce_ORNG_MT19937PHP;
-PHPAPI zend_class_entry *ce_ORNG_MT19937MB;
+PHP_ORNG_API zend_class_entry *ce_ORNG_MT19937;
+PHP_ORNG_API zend_class_entry *ce_ORNG_MT19937PHP;
+PHP_ORNG_API zend_class_entry *ce_ORNG_MT19937MB;
 
 static zend_object_handlers oh_MT19937;
 

--- a/rng/mt19937.h
+++ b/rng/mt19937.h
@@ -23,9 +23,9 @@
 
 # include "../orng_util.h"
 
-extern PHPAPI zend_class_entry *ce_ORNG_MT19937;
-extern PHPAPI zend_class_entry *ce_ORNG_MT19937PHP;
-extern PHPAPI zend_class_entry *ce_ORNG_MT19937MB;
+extern PHP_ORNG_API zend_class_entry *ce_ORNG_MT19937;
+extern PHP_ORNG_API zend_class_entry *ce_ORNG_MT19937PHP;
+extern PHP_ORNG_API zend_class_entry *ce_ORNG_MT19937MB;
 
 # define ORNG_MT19937_MT_RAND_MAX ((zend_long) (0x7FFFFFFF))
 

--- a/rng/rnginterface.c
+++ b/rng/rnginterface.c
@@ -32,7 +32,7 @@
 # include "rnginterface_arginfo_7.h"
 #endif
 
-PHPAPI zend_class_entry *orng_ce_ORNG_RNGInterface;
+PHP_ORNG_API zend_class_entry *orng_ce_ORNG_RNGInterface;
 
 PHP_MINIT_FUNCTION(orng_rng_rnginterface)
 {

--- a/rng/rnginterface.h
+++ b/rng/rnginterface.h
@@ -21,7 +21,7 @@
 
 # include "php.h"
 
-extern PHPAPI zend_class_entry *orng_ce_ORNG_RNGInterface;
+extern PHP_ORNG_API zend_class_entry *orng_ce_ORNG_RNGInterface;
 
 PHP_MINIT_FUNCTION(orng_rng_rnginterface);
 

--- a/rng/xorshift128plus.c
+++ b/rng/xorshift128plus.c
@@ -41,7 +41,7 @@
 # include "xorshift128plus_arginfo_7.h"
 #endif
 
-PHPAPI zend_class_entry *ce_ORNG_XorShift128Plus;
+PHP_ORNG_API zend_class_entry *ce_ORNG_XorShift128Plus;
 
 static zend_object_handlers oh_XorShift128Plus;
 

--- a/rng/xorshift128plus.h
+++ b/rng/xorshift128plus.h
@@ -23,7 +23,7 @@
 
 # include "../orng_util.h"
 
-extern PHPAPI zend_class_entry *ce_ORNG_XorShift128Plus;
+extern PHP_ORNG_API zend_class_entry *ce_ORNG_XorShift128Plus;
 
 typedef struct _ORNG_XorShift128Plus_obj {
   uint64_t s[2];


### PR DESCRIPTION
If extensions are built as shared libraries, `PHP_EXPORTS` is not
defined for the extension on Windows, so the `PHPAPI`s are not
exported.  We could fix that by adding a respective define to the
extension build, but that would not allow other extensions to import
the symbols later.  Therefore, we have to define our own export marker.

---

An alternative would be to not export these symbols at all.